### PR TITLE
chore: update dicom-core dependency to pypi index.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,4 +6,4 @@ gitpython==3.*
 pydantic==2.*
 pint==0.*
 typer[all]==0.*
-dicom-core[nifti] @ git+ssh://git@github.com/gold-standard-phantoms/dicom-core.git@fae4169
+dicom-core[nifti]>=0.4.1.dev17


### PR DESCRIPTION
Reverting to use pypi index to try resolve an issue with setting up prokects that depend on mr-image-tools.