### PR TITLE
feat: make dicom-core an optional dependency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,4 +6,3 @@ gitpython==3.*
 pydantic==2.*
 pint==0.*
 typer[all]==0.*
-dicom-core[nifti] @ git+ssh://git@github.com/gold-standard-phantoms/dicom-core.git@fae4169

--- a/requirements/extras/dicom.txt
+++ b/requirements/extras/dicom.txt
@@ -1,0 +1,1 @@
+dicom-core[nifti] @ git+ssh://git@github.com/gold-standard-phantoms/dicom-core.git@fae4169

--- a/src/mrimagetools/v2/containers/image.py
+++ b/src/mrimagetools/v2/containers/image.py
@@ -7,21 +7,31 @@ from __future__ import annotations
 import pathlib
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import nibabel as nib
 import numpy as np
 import numpy.typing as npt
-from dicom_core.nifti.dcm2niix import Dcm2NiixConfig
-from dicom_core.nifti.load import (
-    DicomToNiftiConfig,
-    SeriesInstanceUID,
-    SeriesSelection,
-    SingleSeriesData,
-    dicom_to_nifti,
-)
 
 from mrimagetools.v2.containers.image_metadata import ImageMetadata
+
+# Optional dicom-core dependency
+try:
+    from dicom_core.nifti.dcm2niix import Dcm2NiixConfig
+    from dicom_core.nifti.load import (
+        DicomToNiftiConfig,
+        SeriesInstanceUID,
+        SeriesSelection,
+        SingleSeriesData,
+        dicom_to_nifti,
+    )
+
+    _DICOM_AVAILABLE = True
+except ImportError:
+    _DICOM_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from dicom_core.nifti.load import SingleSeriesData
 
 UNITS_UNKNOWN = "unknown"
 UNITS_METERS = "meter"
@@ -417,7 +427,14 @@ class DicomImageContainer(BaseImageContainer):
         :raises ValueError: if more than one, or zero series, are found using the
             supplied config
         :raises DicomToNiftiError: if the DICOM to NIfTI conversion fails
+        :raises ImportError: if the 'dicom' extra is not installed
         """
+        if not _DICOM_AVAILABLE:
+            raise ImportError(
+                "DicomImageContainer requires the 'dicom' extra. "
+                "Install with: pip install mrimagetools[dicom]"
+            )
+
         if isinstance(directory, pathlib.Path):
             directory = directory.resolve()
         else:


### PR DESCRIPTION
Move dicom-core from required dependencies to optional extras, allowing users without access to the private repository to install and use mrimagetools. DicomImageContainer is now only available when installed with pip install mrimagetools[dicom].

Ref: MIT-155